### PR TITLE
style: Reformat code

### DIFF
--- a/benchmark/container/forward_list_benchmark.cpp
+++ b/benchmark/container/forward_list_benchmark.cpp
@@ -36,8 +36,8 @@ TEST_CASE(
         .run(
             "forfun::experimental::container::forward_list<std::integral T>",
             []() {
-                forfun::experimental::container::forward_list<int> forward_list{
-                };
+                forfun::experimental::container::forward_list<int>
+                    forward_list{};
                 forward_list.push_front(1301);
 
                 auto const r{forward_list.front()};

--- a/benchmark/palindrome_benchmark.cpp
+++ b/benchmark/palindrome_benchmark.cpp
@@ -56,7 +56,8 @@ TEST_CASE("Palindrome benchmarking", "[benchmark][palindrome]")
             .run(
                 NAMEOF_RAW(functional::bloated::is_palindrome<char>).c_str(),
                 [&palindrome]() noexcept {
-                    auto const r{functional::bloated::is_palindrome(palindrome)
+                    auto const r{
+                        functional::bloated::is_palindrome(palindrome)
                     };
 
                     ankerl::nanobench::doNotOptimizeAway(r);

--- a/benchmark/valid_anagram_benchmark.cpp
+++ b/benchmark/valid_anagram_benchmark.cpp
@@ -36,7 +36,8 @@ TEST_CASE("Valid anagram benchmarking", "[benchmark][valid_anagram]")
         .run(
             NAMEOF_RAW(generic::is_anagram<char>).c_str(),
             []() noexcept(false) {
-                bool const r{generic::is_anagram<char>("anagram"sv, "nagaram"sv)
+                bool const r{
+                    generic::is_anagram<char>("anagram"sv, "nagaram"sv)
                 };
 
                 ankerl::nanobench::doNotOptimizeAway(r);

--- a/include/forfun/valid_anagram.hpp
+++ b/include/forfun/valid_anagram.hpp
@@ -38,8 +38,8 @@ template <std::integral CharT>
         return false;
     }
 
-    std::multiset<typename std::basic_string_view<CharT>::value_type> haystack{
-    };
+    std::multiset<typename std::basic_string_view<CharT>::value_type>
+        haystack{};
 
     if constexpr (requires { haystack.insert_range(s); })
     {

--- a/test/factorial_test.cpp
+++ b/test/factorial_test.cpp
@@ -120,7 +120,8 @@ TEMPLATE_TEST_CASE(
     SECTION("20! is 2,432,902,008,176,640,000")
     {
         auto const volatile n{TestType{20}};
-        static constexpr auto const expected{TestType{2'432'902'008'176'640'000}
+        static constexpr auto const expected{
+            TestType{2'432'902'008'176'640'000}
         };
 
         REQUIRE(forfun::factorial::iterative::factorial(n) == expected);

--- a/test/project_euler/p0001_multiples_of_3_or_5_test.cpp
+++ b/test/project_euler/p0001_multiples_of_3_or_5_test.cpp
@@ -25,7 +25,8 @@ TEST_CASE("Multiples of three or five", "[multiples_of_3_or_5]")
 
     SECTION("Find the sum of all the multiples of 3 or 5 up to 1 (static)")
     {
-        static constexpr unsigned int const actual{find_sum_mult_three_five(1U)
+        static constexpr unsigned int const actual{
+            find_sum_mult_three_five(1U)
         };
 
         STATIC_REQUIRE(actual == 0U);
@@ -33,7 +34,8 @@ TEST_CASE("Multiples of three or five", "[multiples_of_3_or_5]")
 
     SECTION("Find the sum of all the multiples of 3 or 5 up to 3 (static)")
     {
-        static constexpr unsigned int const actual{find_sum_mult_three_five(3U)
+        static constexpr unsigned int const actual{
+            find_sum_mult_three_five(3U)
         };
 
         STATIC_REQUIRE(actual == 3U);
@@ -41,7 +43,8 @@ TEST_CASE("Multiples of three or five", "[multiples_of_3_or_5]")
 
     SECTION("Find the sum of all the multiples of 3 or 5 up to 4 (static)")
     {
-        static constexpr unsigned int const actual{find_sum_mult_three_five(4U)
+        static constexpr unsigned int const actual{
+            find_sum_mult_three_five(4U)
         };
 
         STATIC_REQUIRE(actual == 3U);
@@ -49,7 +52,8 @@ TEST_CASE("Multiples of three or five", "[multiples_of_3_or_5]")
 
     SECTION("Find the sum of all the multiples of 3 or 5 up to 6 (static)")
     {
-        static constexpr unsigned int const actual{find_sum_mult_three_five(6U)
+        static constexpr unsigned int const actual{
+            find_sum_mult_three_five(6U)
         };
 
         STATIC_REQUIRE(actual == 14U);
@@ -57,7 +61,8 @@ TEST_CASE("Multiples of three or five", "[multiples_of_3_or_5]")
 
     SECTION("Find the sum of all the multiples of 3 or 5 up to 10 (static)")
     {
-        static constexpr unsigned int const actual{find_sum_mult_three_five(10U)
+        static constexpr unsigned int const actual{
+            find_sum_mult_three_five(10U)
         };
 
         STATIC_REQUIRE(actual == 33U);

--- a/test/valid_parentheses_test.cpp
+++ b/test/valid_parentheses_test.cpp
@@ -91,7 +91,8 @@ TEMPLATE_TEST_CASE_SIG(
 
         SECTION("[]{{{{{()}}}}}(([[[[]]]]))")
         {
-            constexpr std::u8string_view const s{u8"[]{{{{{()}}}}}(([[[[]]]]))"
+            constexpr std::u8string_view const s{
+                u8"[]{{{{{()}}}}}(([[[[]]]]))"
             };
 
             CAPTURE(s);


### PR DESCRIPTION
Reformat code with Ubuntu clang-format version 20.0.0 (++20241020083338+e6c01432b6fb-1~exp1~20241020083515.488)