### PR TITLE
feat: Add wait-free SPSC append-only bounded queue

### DIFF
--- a/.github/workflows/building-and-testing.yml
+++ b/.github/workflows/building-and-testing.yml
@@ -97,6 +97,14 @@ jobs:
           --success
         working-directory: ${{ env.BINARY_DIR }}
 
+      - name: Run test driver of lock-free concurrency library
+        run: >-
+          .\test_driver_concurrency_lf.exe
+          --order rand
+          --reporter console::out=-::colour-mode=ansi
+          --success
+        working-directory: ${{ env.BINARY_DIR }}
+
       - name: Run benchmarks
         run: >-
           .\benchmark_driver.exe
@@ -191,6 +199,14 @@ jobs:
           MIMALLOC_VERBOSE: 1
         run: >-
           .\test_driver_experimental.exe
+          --order rand
+          --reporter console::out=-::colour-mode=ansi
+          --success
+        working-directory: ${{ env.BINARY_DIR }}
+
+      - name: Run test driver of lock-free concurrency library
+        run: >-
+          .\test_driver_concurrency_lf.exe
           --order rand
           --reporter console::out=-::colour-mode=ansi
           --success
@@ -295,7 +311,7 @@ jobs:
           --success
         working-directory: ${{ env.BINARY_DIR }}
 
-      - name: Run and instrument test driver of experimental library
+      - name: Check test driver of experimental library with Valgrind Memcheck
         env:
           MIMALLOC_SHOW_ERRORS: 1
           MIMALLOC_SHOW_STATS: 1
@@ -313,6 +329,26 @@ jobs:
           --success
         working-directory: ${{ env.BINARY_DIR }}
 
+      - name: Check test driver of lock-free concurrency library with Valgrind Memcheck
+        run: >-
+          /usr/bin/valgrind
+          --tool=memcheck
+          --leak-check=full
+          --show-leak-kinds=all
+          ./test_driver_concurrency_lf
+          --order rand
+          --reporter console::out=-::colour-mode=ansi
+          --success
+        working-directory: ${{ env.BINARY_DIR }}
+
+      - name: Run concurrency library test driver
+        run: >-
+          ./test_driver_concurrency_lf
+          --order rand
+          --reporter console::out=-::colour-mode=ansi
+          --success
+        working-directory: ${{ env.BINARY_DIR }}
+
       - name: Run benchmarks
         run: >-
           ./benchmark_driver
@@ -323,6 +359,13 @@ jobs:
       - name: Run benchmarks of experimental library
         run: >-
           ./benchmark_driver_experimental
+          --durations yes
+          --reporter console::out=-::colour-mode=ansi
+        working-directory: ${{ env.BINARY_DIR }}
+
+      - name: Run benchmarks of lock-free concurrency library
+        run: >-
+          ./benchmark_driver_concurrency_lf
           --durations yes
           --reporter console::out=-::colour-mode=ansi
         working-directory: ${{ env.BINARY_DIR }}
@@ -412,7 +455,7 @@ jobs:
           --success
         working-directory: ${{ env.BINARY_DIR }}
 
-      - name: Run and instrument test driver of experimental library
+      - name: Check test driver of experimental library with Valgrind Memcheck
         env:
           MIMALLOC_SHOW_ERRORS: 1
           MIMALLOC_SHOW_STATS: 1
@@ -425,6 +468,27 @@ jobs:
           --leak-check=full
           --show-leak-kinds=all
           ./test_driver_experimental
+          --order rand
+          --reporter console::out=-::colour-mode=ansi
+          --success
+        working-directory: ${{ env.BINARY_DIR }}
+
+      - name: Check test driver of lock-free concurrency library with Valgrind Memcheck
+        run: >-
+          /usr/bin/valgrind
+          --error-exitcode=1
+          --tool=memcheck
+          --leak-check=full
+          --show-leak-kinds=all
+          ./test_driver_concurrency_lf
+          --order rand
+          --reporter console::out=-::colour-mode=ansi
+          --success
+        working-directory: ${{ env.BINARY_DIR }}
+
+      - name: Run concurrency library test driver
+        run: >-
+          ./test_driver_concurrency_lf
           --order rand
           --reporter console::out=-::colour-mode=ansi
           --success
@@ -444,10 +508,18 @@ jobs:
           --reporter console::out=-::colour-mode=ansi
         working-directory: ${{ env.BINARY_DIR }}
 
-  apple_clang_debug_aarch64_macos:
-    name: Build (Apple Clang Debug AArch64 macOS)
+      - name: Run benchmarks of lock-free concurrency library
+        run: >-
+          ./benchmark_driver_concurrency_lf
+          --durations yes
+          --reporter console::out=-::colour-mode=ansi
+        working-directory: ${{ env.BINARY_DIR }}
+
+  apple_clang_asan_ubsan_debug_aarch64_macos:
+    name: Build (Apple Clang ASan UBSan Debug AArch64 macOS)
     env:
       CONFIGURE_PRESET_NAME: xcode
+      BINARY_DIR: ${{ github.workspace }}/out/build/xcode/Debug
       BUILD_DIR: ${{ github.workspace }}/out/build/xcode
       BUILD_CONFIGURATION: Debug
       VCPKG_BINARY_SOURCES: clear;nuget,GitHubPackages,readwrite
@@ -517,7 +589,7 @@ jobs:
           --order rand
           --reporter console::out=-::colour-mode=ansi
           --success
-        working-directory: ${{ env.BUILD_DIR }}/${{ env.BUILD_CONFIGURATION }}
+        working-directory: ${{ env.BINARY_DIR }}
 
       - name: Run static test driver
         run: >-
@@ -525,7 +597,7 @@ jobs:
           --order rand
           --reporter console::out=-::colour-mode=ansi
           --success
-        working-directory: ${{ env.BUILD_DIR }}/${{ env.BUILD_CONFIGURATION }}
+        working-directory: ${{ env.BINARY_DIR }}
 
       - name: Run test driver of experimental library
         env:
@@ -537,26 +609,166 @@ jobs:
           --order rand
           --reporter console::out=-::colour-mode=ansi
           --success
-        working-directory: ${{ env.BUILD_DIR }}/${{ env.BUILD_CONFIGURATION }}
+        working-directory: ${{ env.BINARY_DIR }}
+
+      - name: Run test driver of lock-free concurrency library
+        run: >-
+          ./test_driver_concurrency_lf
+          --order rand
+          --reporter console::out=-::colour-mode=ansi
+          --success
+        working-directory: ${{ env.BINARY_DIR }}
 
       - name: Run benchmarks
         run: >-
           ./benchmark_driver
           --durations yes
           --reporter console::out=-::colour-mode=ansi
-        working-directory: ${{ env.BUILD_DIR }}/${{ env.BUILD_CONFIGURATION }}
+        working-directory: ${{ env.BINARY_DIR }}
 
       - name: Run benchmarks of experimental library
         run: >-
           ./benchmark_driver_experimental
           --durations yes
           --reporter console::out=-::colour-mode=ansi
-        working-directory: ${{ env.BUILD_DIR }}/${{ env.BUILD_CONFIGURATION }}
+        working-directory: ${{ env.BINARY_DIR }}
+
+      - name: Run benchmarks of lock-free concurrency library
+        run: >-
+          ./benchmark_driver_concurrency_lf
+          --durations yes
+          --reporter console::out=-::colour-mode=ansi
+        working-directory: ${{ env.BINARY_DIR }}
+
+  apple_clang_tsan_debug_aarch64_macos:
+    name: Build (Apple Clang TSan Debug AArch64 macOS)
+    env:
+      CONFIGURE_PRESET_NAME: xcode
+      BINARY_DIR: ${{ github.workspace }}/out/build/xcode/Debug
+      BUILD_DIR: ${{ github.workspace }}/out/build/xcode
+      BUILD_CONFIGURATION: Debug
+      VCPKG_BINARY_SOURCES: clear;nuget,GitHubPackages,readwrite
+      XCODE_RELEASE: "26.5"
+
+    runs-on: macos-26
+
+    steps:
+      - name: Set default Xcode release
+        run: >-
+          sudo xcode-select
+          -switch '/Applications/Xcode_${{ env.XCODE_RELEASE }}.app'
+
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install tools
+        run: >-
+          brew install mono
+
+      - name: Check out vcpkg
+        uses: actions/checkout@v6
+        with:
+          repository: microsoft/vcpkg
+          path: ${{ github.workspace }}/vcpkg
+          persist-credentials: false
+
+      - name: Bootstrap vcpkg
+        run: ${{ github.workspace }}/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+
+      - name: Add NuGet sources
+        env:
+          FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+        run: >-
+          mono `${{ github.workspace }}/vcpkg/vcpkg fetch nuget | tail -n 1`
+          sources add
+          -source "${{ env.FEED_URL }}"
+          -storepasswordincleartext
+          -name "GitHubPackages"
+          -username "${{ github.repository_owner }}"
+          -password "${{ secrets.GITHUB_TOKEN }}"
+
+          mono `${{ github.workspace }}/vcpkg/vcpkg fetch nuget | tail -n 1`
+          setapikey "${{ secrets.GITHUB_TOKEN }}"
+          -source "${{ env.FEED_URL }}"
+
+      - name: Configure CMake
+        run: >-
+          cmake
+          --preset '${{ env.CONFIGURE_PRESET_NAME }}'
+
+      - name: Build with sanitizers
+        run: >-
+          cmake
+          --build '${{ env.BUILD_DIR }}'
+          --config '${{ env.BUILD_CONFIGURATION }}'
+          --parallel
+          --
+          -enableThreadSanitizer YES
+
+      - name: Run test driver
+        run: >-
+          ./test_driver
+          --order rand
+          --reporter console::out=-::colour-mode=ansi
+          --success
+        working-directory: ${{ env.BINARY_DIR }}
+
+      - name: Run static test driver
+        run: >-
+          ./static_test_driver
+          --order rand
+          --reporter console::out=-::colour-mode=ansi
+          --success
+        working-directory: ${{ env.BINARY_DIR }}
+
+      - name: Run test driver of experimental library
+        env:
+          MIMALLOC_SHOW_ERRORS: 1
+          MIMALLOC_SHOW_STATS: 1
+          MIMALLOC_VERBOSE: 1
+        run: >-
+          ./test_driver_experimental
+          --order rand
+          --reporter console::out=-::colour-mode=ansi
+          --success
+        working-directory: ${{ env.BINARY_DIR }}
+
+      - name: Run test driver of lock-free concurrency library
+        run: >-
+          ./test_driver_concurrency_lf
+          --order rand
+          --reporter console::out=-::colour-mode=ansi
+          --success
+        working-directory: ${{ env.BINARY_DIR }}
+
+      - name: Run benchmarks
+        run: >-
+          ./benchmark_driver
+          --durations yes
+          --reporter console::out=-::colour-mode=ansi
+        working-directory: ${{ env.BINARY_DIR }}
+
+      - name: Run benchmarks of experimental library
+        run: >-
+          ./benchmark_driver_experimental
+          --durations yes
+          --reporter console::out=-::colour-mode=ansi
+        working-directory: ${{ env.BINARY_DIR }}
+
+      - name: Run benchmarks of lock-free concurrency library
+        run: >-
+          ./benchmark_driver_concurrency_lf
+          --durations yes
+          --reporter console::out=-::colour-mode=ansi
+        working-directory: ${{ env.BINARY_DIR }}
 
   apple_clang_release_aarch64_macos:
     name: Build (Apple Clang Release AArch64 macOS)
     env:
       CONFIGURE_PRESET_NAME: xcode
+      BINARY_DIR: ${{ github.workspace }}/out/build/xcode/Release
       BUILD_DIR: ${{ github.workspace }}/out/build/xcode
       BUILD_CONFIGURATION: Release
       VCPKG_BINARY_SOURCES: clear;nuget,GitHubPackages,readwrite
@@ -623,7 +835,7 @@ jobs:
           --order rand
           --reporter console::out=-::colour-mode=ansi
           --success
-        working-directory: ${{ env.BUILD_DIR }}/${{ env.BUILD_CONFIGURATION }}
+        working-directory: ${{ env.BINARY_DIR }}
 
       - name: Run static test driver
         run: >-
@@ -631,7 +843,7 @@ jobs:
           --order rand
           --reporter console::out=-::colour-mode=ansi
           --success
-        working-directory: ${{ env.BUILD_DIR }}/${{ env.BUILD_CONFIGURATION }}
+        working-directory: ${{ env.BINARY_DIR }}
 
       - name: Run test driver of experimental library
         env:
@@ -643,21 +855,36 @@ jobs:
           --order rand
           --reporter console::out=-::colour-mode=ansi
           --success
-        working-directory: ${{ env.BUILD_DIR }}/${{ env.BUILD_CONFIGURATION }}
+        working-directory: ${{ env.BINARY_DIR }}
+
+      - name: Run test driver of lock-free concurrency library
+        run: >-
+          ./test_driver_concurrency_lf
+          --order rand
+          --reporter console::out=-::colour-mode=ansi
+          --success
+        working-directory: ${{ env.BINARY_DIR }}
 
       - name: Run benchmarks
         run: >-
           ./benchmark_driver
           --durations yes
           --reporter console::out=-::colour-mode=ansi
-        working-directory: ${{ env.BUILD_DIR }}/${{ env.BUILD_CONFIGURATION }}
+        working-directory: ${{ env.BINARY_DIR }}
 
       - name: Run benchmarks of experimental library
         run: >-
           ./benchmark_driver_experimental
           --durations yes
           --reporter console::out=-::colour-mode=ansi
-        working-directory: ${{ env.BUILD_DIR }}/${{ env.BUILD_CONFIGURATION }}
+        working-directory: ${{ env.BINARY_DIR }}
+
+      - name: Run benchmarks of lock-free concurrency library
+        run: >-
+          ./benchmark_driver_concurrency_lf
+          --durations yes
+          --reporter console::out=-::colour-mode=ansi
+        working-directory: ${{ env.BINARY_DIR }}
 
   clang_debug_x86_64_linux:
     name: Build (Clang Debug x86-64 Linux)
@@ -768,7 +995,7 @@ jobs:
           --success
         working-directory: ${{ env.BINARY_DIR }}
 
-      - name: Run and instrument test driver of experimental library
+      - name: Check test driver of experimental library with Valgrind Memcheck
         env:
           MIMALLOC_SHOW_ERRORS: 1
           MIMALLOC_SHOW_STATS: 1
@@ -786,6 +1013,27 @@ jobs:
           --success
         working-directory: ${{ env.BINARY_DIR }}
 
+      - name: Check test driver of lock-free concurrency library with Valgrind Memcheck
+        run: >-
+          /usr/bin/valgrind
+          --error-exitcode=1
+          --tool=memcheck
+          --leak-check=full
+          --show-leak-kinds=all
+          ./test_driver_concurrency_lf
+          --order rand
+          --reporter console::out=-::colour-mode=ansi
+          --success
+        working-directory: ${{ env.BINARY_DIR }}
+
+      - name: Run concurrency library test driver
+        run: >-
+          ./test_driver_concurrency_lf
+          --order rand
+          --reporter console::out=-::colour-mode=ansi
+          --success
+        working-directory: ${{ env.BINARY_DIR }}
+
       - name: Run benchmarks
         run: >-
           ./benchmark_driver
@@ -796,6 +1044,13 @@ jobs:
       - name: Run benchmarks of experimental library
         run: >-
           ./benchmark_driver_experimental
+          --durations yes
+          --reporter console::out=-::colour-mode=ansi
+        working-directory: ${{ env.BINARY_DIR }}
+
+      - name: Run benchmarks of lock-free concurrency library
+        run: >-
+          ./benchmark_driver_concurrency_lf
           --durations yes
           --reporter console::out=-::colour-mode=ansi
         working-directory: ${{ env.BINARY_DIR }}
@@ -909,7 +1164,7 @@ jobs:
           --success
         working-directory: ${{ env.BINARY_DIR }}
 
-      - name: Run and instrument test driver of experimental library
+      - name: Check test driver of experimental library with Valgrind Memcheck
         env:
           MIMALLOC_SHOW_ERRORS: 1
           MIMALLOC_SHOW_STATS: 1
@@ -921,6 +1176,27 @@ jobs:
           --leak-check=full
           --show-leak-kinds=all
           ./test_driver_experimental
+          --order rand
+          --reporter console::out=-::colour-mode=ansi
+          --success
+        working-directory: ${{ env.BINARY_DIR }}
+
+      - name: Check test driver of lock-free concurrency library with Valgrind Memcheck
+        run: >-
+          /usr/bin/valgrind
+          --error-exitcode=1
+          --tool=memcheck
+          --leak-check=full
+          --show-leak-kinds=all
+          ./test_driver_concurrency_lf
+          --order rand
+          --reporter console::out=-::colour-mode=ansi
+          --success
+        working-directory: ${{ env.BINARY_DIR }}
+
+      - name: Run concurrency library test driver
+        run: >-
+          ./test_driver_concurrency_lf
           --order rand
           --reporter console::out=-::colour-mode=ansi
           --success
@@ -940,11 +1216,11 @@ jobs:
           --reporter console::out=-::colour-mode=ansi
         working-directory: ${{ env.BINARY_DIR }}
 
-  clang_sanitizers:
+  clang_asan_ubsan:
     name: Build (Clang AddressSanitizer and UndefinedBehaviorSanitizer)
     env:
-      CONFIGURE_PRESET_NAME: clang-sanitizers
-      BINARY_DIR: ${{ github.workspace }}/out/build/clang-sanitizers
+      CONFIGURE_PRESET_NAME: clang-asan-ubsan
+      BINARY_DIR: ${{ github.workspace }}/out/build/clang-asan-ubsan
       VCPKG_BINARY_SOURCES: clear;nuget,GitHubPackages,readwrite
       ASAN_OPTIONS: check_initialization_order=1:detect_stack_use_after_return=1:detect_leaks=1
       ASAN_SYMBOLIZER_PATH: /usr/bin/llvm-symbolizer-22
@@ -1051,6 +1327,14 @@ jobs:
           --reporter console::out=-::colour-mode=ansi
         working-directory: ${{ env.BINARY_DIR }}
 
+      - name: Run and instrument test driver of lock-free concurrency library
+        run: >-
+          ./test_driver_concurrency_lf
+          --order rand
+          --reporter console::out=-::colour-mode=ansi
+          --success
+        working-directory: ${{ env.BINARY_DIR }}
+
       - name: Run benchmarks
         run: >-
           ./benchmark_driver
@@ -1060,5 +1344,105 @@ jobs:
       - name: Run benchmarks of experimental library
         run: >-
           ./benchmark_driver_experimental
+          --reporter console::out=-::colour-mode=ansi
+        working-directory: ${{ env.BINARY_DIR }}
+
+  clang_thread_sanitizers:
+    name: Build (Clang ThreadSanitizer)
+    env:
+      CONFIGURE_PRESET_NAME: clang-tsan
+      BINARY_DIR: ${{ github.workspace }}/out/build/clang-tsan
+      TSAN_OPTIONS: enable_adaptive_delay=1:adaptive_delay_aggressiveness=50
+      VCPKG_BINARY_SOURCES: clear;nuget,GitHubPackages,readwrite
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Retrieve the LLVM archive signature
+        run: |-
+          echo "Types: deb
+          URIs: http://apt.llvm.org/noble/
+          Suites: llvm-toolchain-noble-22
+          Components: main
+          Signed-By:
+          $(wget --output-document \
+          - https://apt.llvm.org/llvm-snapshot.gpg.key \
+          | sed -e 's/^$/./' -e 's/^/ /')" \
+          | sudo tee /etc/apt/sources.list.d/llvm-toolchain-noble.sources \
+          > /dev/null
+
+      - name: Install tools
+        run: >-
+          sudo apt-get update
+
+          sudo apt-get install
+          clang-22
+          clang-tools-22
+          libc++-22-dev
+          libc++-22
+          libc++abi-22-dev
+          mono-complete
+          ninja-build
+
+          sudo update-alternatives
+          --install /usr/bin/cc cc /usr/bin/clang-22 100
+
+          sudo update-alternatives
+          --install /usr/bin/c++ c++ /usr/bin/clang++-22 100
+
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Check out vcpkg
+        uses: actions/checkout@v6
+        with:
+          repository: microsoft/vcpkg
+          path: ${{ github.workspace }}/vcpkg
+          persist-credentials: false
+
+      - name: Bootstrap vcpkg
+        run: ${{ github.workspace }}/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+
+      - name: Add NuGet sources
+        env:
+          FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+        run: >-
+          mono `${{ github.workspace }}/vcpkg/vcpkg fetch nuget | tail -n 1`
+          sources add
+          -source "${{ env.FEED_URL }}"
+          -storepasswordincleartext
+          -name "GitHubPackages"
+          -username "${{ github.repository_owner }}"
+          -password "${{ secrets.GITHUB_TOKEN }}"
+
+          mono `${{ github.workspace }}/vcpkg/vcpkg fetch nuget | tail -n 1`
+          setapikey "${{ secrets.GITHUB_TOKEN }}"
+          -source "${{ env.FEED_URL }}"
+
+      - name: Configure CMake
+        run: >-
+          cmake
+          --preset '${{ env.CONFIGURE_PRESET_NAME }}'
+
+      - name: Build
+        run: >-
+          cmake
+          --build '${{ env.BINARY_DIR }}'
+          --parallel
+          --target
+          test_driver_concurrency_lf
+          benchmark_driver_concurrency_lf
+
+      - name: Run and instrument of concurrency test driver
+        run: >-
+          ./test_driver_concurrency_lf
+          --order rand
+          --reporter console::out=-::colour-mode=ansi
+        working-directory: ${{ env.BINARY_DIR }}
+
+      - name: Run benchmarks of lock-free concurrency library
+        run: >-
+          ./benchmark_driver_concurrency_lf
           --reporter console::out=-::colour-mode=ansi
         working-directory: ${{ env.BINARY_DIR }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ project(
 
 add_library(forfun)
 add_library(forfun_common)
+add_library(forfun_concurrency_lf)
 add_library(forfun_experimental)
 add_library(forfun_graph)
 add_library(forfun_search)
@@ -26,10 +27,12 @@ add_library(forfun_c)
 add_library(forfun_c_experimental STATIC)
 
 add_executable(test_driver)
+add_executable(test_driver_concurrency_lf)
 add_executable(test_driver_experimental)
 add_executable(static_test_driver)
 
 add_executable(benchmark_driver)
+add_executable(benchmark_driver_concurrency_lf)
 add_executable(benchmark_driver_experimental)
 
 include(cmake/CompileOptions.cmake)
@@ -189,6 +192,43 @@ source_group(
   FILES ${forfun_common_sources}
 )
 forfun_common_target_compile_options(forfun_common)
+
+target_include_directories(
+  forfun_concurrency_lf
+  INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include>"
+)
+target_sources(
+  forfun_concurrency_lf
+  PUBLIC
+  FILE_SET HEADERS
+  BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
+  FILES
+  "${CMAKE_CURRENT_SOURCE_DIR}/include/forfun/concurrency/spsc_bound_queue.hpp"
+)
+target_sources(
+  forfun_concurrency_lf
+  PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/forfun/concurrency/spsc_bound_queue.cpp"
+)
+
+get_target_property(
+  forfun_concurrency_lf_headers
+  forfun_concurrency_lf
+  HEADER_SET
+)
+source_group(
+  TREE "${CMAKE_CURRENT_SOURCE_DIR}/include/forfun/concurrency/"
+  PREFIX "Header files"
+  FILES ${forfun_concurrency_lf_headers}
+)
+get_target_property(forfun_concurrency_lf_sources forfun_concurrency_lf SOURCES)
+source_group(
+  TREE "${CMAKE_CURRENT_SOURCE_DIR}/src/forfun/concurrency"
+  PREFIX "Source files"
+  FILES ${forfun_concurrency_lf_sources}
+)
 
 target_include_directories(
   forfun_graph
@@ -556,6 +596,36 @@ target_link_libraries(
 forfun_common_target_compile_options(test_driver)
 
 target_compile_definitions(
+  test_driver_concurrency_lf
+  PRIVATE
+  CATCH_CONFIG_NO_COUNTER
+)
+target_sources(
+  test_driver_concurrency_lf
+  PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}/test/concurrency/spsc_bound_queue_test.cpp"
+)
+get_target_property(
+  test_driver_concurrency_lf_sources
+  test_driver_concurrency_lf
+  SOURCES
+)
+source_group(
+  TREE "${CMAKE_CURRENT_SOURCE_DIR}/test/concurrency/"
+  PREFIX "Source files"
+  FILES ${test_driver_concurrency_lf_sources}
+)
+target_link_libraries(
+  test_driver_concurrency_lf
+  PRIVATE Catch2::Catch2WithMain
+)
+target_link_libraries(
+  test_driver_concurrency_lf
+  PRIVATE forfun_concurrency_lf
+)
+forfun_common_target_compile_options(test_driver_concurrency_lf)
+
+target_compile_definitions(
   test_driver_experimental
   PRIVATE
   CATCH_CONFIG_NO_COUNTER
@@ -600,6 +670,7 @@ include(CTest)
 include(Catch)
 catch_discover_tests(test_driver)
 catch_discover_tests(test_driver_experimental)
+catch_discover_tests(test_driver_concurrency_lf)
 
 find_package(nameof CONFIG REQUIRED)
 find_package(nanobench CONFIG REQUIRED)
@@ -690,6 +761,37 @@ target_link_libraries(
 forfun_common_target_compile_options(benchmark_driver)
 
 target_compile_definitions(
+  benchmark_driver_concurrency_lf
+  PRIVATE
+  CATCH_CONFIG_NO_COUNTER
+)
+target_sources(
+  benchmark_driver_concurrency_lf
+  PRIVATE
+  "${CMAKE_CURRENT_SOURCE_DIR}/benchmark/benchmark.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/benchmark/concurrency/spsc_bound_queue_benchmark.cpp"
+)
+get_target_property(
+  benchmark_driver_concurrency_lf_sources
+  benchmark_driver_concurrency_lf
+  SOURCES
+)
+source_group(
+  TREE "${CMAKE_CURRENT_SOURCE_DIR}/benchmark/"
+  PREFIX "Source files"
+  FILES ${benchmark_driver_concurrency_lf_sources}
+)
+target_link_libraries(
+  benchmark_driver_concurrency_lf
+  PRIVATE Catch2::Catch2WithMain
+)
+target_link_libraries(
+  benchmark_driver_concurrency_lf
+  PRIVATE forfun_concurrency_lf
+)
+forfun_common_target_compile_options(benchmark_driver_concurrency_lf)
+
+target_compile_definitions(
   benchmark_driver_experimental
   PRIVATE
   CATCH_CONFIG_NO_COUNTER
@@ -737,6 +839,7 @@ target_sources(
   "${CMAKE_CURRENT_SOURCE_DIR}/test/array_concatenation_statictest.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/test/common/concepts_statictest.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/test/common/math_statictest.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/test/concurrency/spsc_bound_queue_statictest.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/test/container/forward_list_cycle_statictest.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/test/container/forward_list_statictest.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/test/container/internal/list_const_iterator_statictest.cpp"
@@ -829,6 +932,7 @@ endif()
 
 set_target_properties(
   forfun
+  forfun_concurrency_lf
   forfun_common
   forfun_experimental
   forfun_graph
@@ -843,9 +947,11 @@ set_target_properties(
 
 set_target_properties(
   benchmark_driver
+  benchmark_driver_concurrency_lf
   benchmark_driver_experimental
   static_test_driver
   test_driver
+  test_driver_concurrency_lf
   test_driver_experimental
   PROPERTIES
     CXX_EXTENSIONS OFF
@@ -883,6 +989,7 @@ install(
     forfun_c
     forfun_c_experimental
     forfun_common
+    forfun_concurrency_lf
     forfun_experimental
     forfun_graph
     forfun_search

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -248,8 +248,8 @@
       }
     },
     {
-      "name": "clang-sanitizers",
-      "displayName": "Clang sanitizers",
+      "name": "clang-asan-ubsan",
+      "displayName": "Clang ASan and UBSan",
       "description": "Build with Clang's AddressSanitizer and UndefinedBehaviorSanitizer",
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/out/build/${presetName}",
@@ -261,6 +261,29 @@
         "CMAKE_C_FLAGS": "-fsanitize=undefined,float-divide-by-zero,local-bounds,vptr,nullability -fsanitize=address -fsanitize-address-use-after-return=always -fno-omit-frame-pointer -fno-sanitize-recover=all",
         "CMAKE_CXX_FLAGS": "-D_LIBCPP_ABI_FIX_CITYHASH_IMPLEMENTATION -fno-builtin-std-forward_like -fsanitize=undefined,float-divide-by-zero,local-bounds,vptr,nullability -fsanitize=address -fsanitize-address-use-after-return=always -fno-omit-frame-pointer -fno-sanitize-recover=all",
         "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=undefined,float-divide-by-zero,local-bounds,vptr,nullability -fsanitize=address -fsanitize-address-use-after-return=always -fno-omit-frame-pointer -flto -fvisibility=default -fno-sanitize-recover=all",
+        "CMAKE_COMPILE_WARNING_AS_ERROR": "OFF",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_TOOLCHAIN_FILE": {
+          "value": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake",
+          "type": "FILEPATH"
+        }
+      }
+    },
+    {
+      "name": "clang-tsan",
+      "displayName": "Clang TSan",
+      "description": "Build with Clang's ThreadSanitizer",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/out/build/${presetName}",
+      "installDir": "${sourceDir}/out/install/${presetName}",
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS": "OFF",
+        "CMAKE_C_FLAGS_RELWITHDEBINFO": "-O1 -g -DNDEBUG",
+        "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-O1 -g -DNDEBUG",
+        "CMAKE_C_FLAGS": "-fsanitize=thread -fno-omit-frame-pointer -fno-sanitize-recover=all -fPIE",
+        "CMAKE_CXX_FLAGS": "-fno-builtin-std-forward_like -fsanitize=thread -fPIE -fno-omit-frame-pointer -fno-sanitize-recover=all",
+        "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=thread -pie -flto -fno-omit-frame-pointer -fno-sanitize-recover=all -fvisibility=default",
         "CMAKE_COMPILE_WARNING_AS_ERROR": "OFF",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ leveraged by this project:
 - EditorConfig
 - Markdown
 - Diagramming with Mermaid
+- Lock-free and wait-free algorithms
 
 ## Index
 
@@ -113,6 +114,7 @@ leveraged by this project:
 | Valid Anagram                                                      | [`include/forfun/valid_anagram.hpp`](include/forfun/valid_anagram.hpp)                                                                         |
 | Valid Parentheses                                                  | [`src/forfun/valid_parentheses.cpp`](src/forfun/valid_parentheses.cpp)                                                                         |
 | Valid Sudoku                                                       | [`include/forfun/valid_sudoku.hpp`](include/forfun/valid_sudoku.hpp)                                                                           |
+| Wait-free (lock-free) SPSC append-only bounded queue               | [`include/forfun/concurrency/spsc_bound_queue.hpp`](include/forfun/concurrency/spsc_bound_queue.hpp)                                         |
 
 ## Disclaimer
 

--- a/benchmark/benchmark.cpp
+++ b/benchmark/benchmark.cpp
@@ -7,3 +7,6 @@
 // See https://github.com/martinus/nanobench
 #define ANKERL_NANOBENCH_IMPLEMENT
 #include <nanobench.h> // IWYU pragma: keep
+
+// Shared translation unit. May be compiled and linked by multiple executable
+// build targets.

--- a/benchmark/concurrency/spsc_bound_queue_benchmark.cpp
+++ b/benchmark/concurrency/spsc_bound_queue_benchmark.cpp
@@ -1,0 +1,92 @@
+// Copyright (c) Omar Boukli-Hacene. All rights reserved.
+// Distributed under an MIT-style license that can be
+// found in the LICENSE file.
+
+// SPDX-License-Identifier: MIT
+
+#include <cstddef>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <nanobench.h>
+
+#include <nameof.hpp>
+
+#include "forfun/concurrency/spsc_bound_queue.hpp"
+
+TEST_CASE(
+    "Wait-free SPSC append-only bounded queue benchmarking",
+    "[benchmark][spsc_bound_queue]"
+)
+{
+    using namespace forfun::concurrency;
+
+    static constexpr std::size_t const capacity{16};
+
+    ankerl::nanobench::Bench()
+
+        .title("Wait-free SPSC append-only bounded queue")
+        .relative(true)
+
+        .run(
+            NAMEOF_RAW(wait_free::spsc_bound_queue<int, capacity>{}).c_str(),
+            [] noexcept -> void {
+                // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+                int volatile val /*[[indeterminate]]*/;
+
+                wait_free::spsc_bound_queue<int, capacity> queue{};
+
+                queue.emplace_back(502807);
+                val = queue.to_span().back();
+
+                queue.emplace_back(502807);
+                val = queue.to_span().back();
+
+                queue.emplace_back(502807);
+                val = queue.to_span().back();
+
+                queue.emplace_back(502807);
+                val = queue.to_span().back();
+
+                queue.emplace_back(502807);
+                val = queue.to_span().back();
+
+                queue.emplace_back(502807);
+                val = queue.to_span().back();
+
+                queue.emplace_back(502807);
+                val = queue.to_span().back();
+
+                queue.emplace_back(502807);
+                val = queue.to_span().back();
+
+                queue.emplace_back(502807);
+                val = queue.to_span().back();
+
+                queue.emplace_back(502807);
+                val = queue.to_span().back();
+
+                queue.emplace_back(502807);
+                val = queue.to_span().back();
+
+                queue.emplace_back(502807);
+                val = queue.to_span().back();
+
+                queue.emplace_back(502807);
+                val = queue.to_span().back();
+
+                queue.emplace_back(502807);
+                val = queue.to_span().back();
+
+                queue.emplace_back(502807);
+                val = queue.to_span().back();
+
+                queue.emplace_back(502807);
+                val = queue.to_span().back();
+
+                ankerl::nanobench::doNotOptimizeAway(&val);
+            }
+        )
+
+        ;
+}

--- a/ci/generate_coverage_report.sh
+++ b/ci/generate_coverage_report.sh
@@ -12,6 +12,7 @@ IGNORE_FILENAME_REGEX="${IGNORE_FILENAME_REGEX:-benchmark|fuzz|test[\/\\].+}"
 
 DRIVERS=(
   'test_driver'
+  'test_driver_concurrency_lf'
   'test_driver_experimental'
 )
 

--- a/docs/developer_notes.md
+++ b/docs/developer_notes.md
@@ -57,7 +57,19 @@ variable.
 
 ### Thread safety
 
-The code is not guaranteed to be thread-safe.
+Data structures in the `forfun_concurrency_lf` library are designed
+to be thread-safe within certain documented constraints. The library specializes
+in lock-free concurrency models, implemented on C++ atomic types and operations.
+
+The thread error detector tool Helgrind might report possible data races
+in the `forfun_concurrency_lf` library, as Helgrind intercepts POSIX threading
+primitives, which `forfun_concurrency_lf` might not use. There is no evidence
+the said data races are true positives.
+
+The `forfun_c_experimental` is, by design, thread-unsafe.
+
+The remaining `forfun` libraries are not, necessarily, designed
+to be thread-safe.
 
 ### Curiously recurring template pattern
 
@@ -247,21 +259,24 @@ This document is not AI-generated.
 
 ## Build artifacts
 
-| Artifact                      | Type                               |
-| ---                           | ---                                |
-| forfun                        | C++23 (static or shared) library   |
-| forfun_graph                  | C++23 (static or shared) library   |
-| forfun_search                 | C++23 (static or shared) library   |
-| forfun_sorting                | C++23 (static or shared) library   |
-| forfun_experimental           | C++23 (static or shared) library   |
-| forfun_c                      | C90 (static or shared) library     |
-| forfun_c_experimental         | C90 static library                 |
-| test_driver                   | Executable Catch2 host             |
-| test_driver_experimental      | Executable Catch2 host             |
-| static_test_driver            | Executable Catch2 host             |
-| benchmark_driver              | Executable Catch2 host             |
-| benchmark_driver_experimental | Executable Catch2 host             |
-| fuzzing_driver                | Executable FuzzTest host           |
+| Artifact                        | Type                               |
+| ---                             | ---                                |
+| forfun                          | C++23 (static or shared) library   |
+| forfun_concurrency_lf           | C++23 (static or shared) library   |
+| forfun_graph                    | C++23 (static or shared) library   |
+| forfun_search                   | C++23 (static or shared) library   |
+| forfun_sorting                  | C++23 (static or shared) library   |
+| forfun_experimental             | C++23 (static or shared) library   |
+| forfun_c                        | C90 (static or shared) library     |
+| forfun_c_experimental           | C90 static library                 |
+| test_driver                     | Executable Catch2 host             |
+| test_driver_concurrency_lf      | Executable Catch2 host             |
+| test_driver_experimental        | Executable Catch2 host             |
+| static_test_driver              | Executable Catch2 host             |
+| benchmark_driver                | Executable Catch2 host             |
+| benchmark_driver_concurrency_lf | Executable Catch2 host             |
+| benchmark_driver_experimental   | Executable Catch2 host             |
+| fuzzing_driver                  | Executable FuzzTest host           |
 
 ## Problem-specific notes
 

--- a/docs/problem_alias.md
+++ b/docs/problem_alias.md
@@ -12,17 +12,18 @@ Names and titles follow those of STL and Wikipedia.
 
 ### Algorithms, data structures, and patterns
 
-| Name                              |
-| ---                               |
-| Breadth-First Search              |
-| Depth-First Search                |
-| Factorial                         |
-| Forward List                      |
-| Greatest Common Divisor           |
-| Integer division ceiling          |
-| List Bidirectional Iterator       |
-| Primality Test                    |
-| Tower of Hanoi                    |
+| Name                                                 |
+| ---                                                  |
+| Breadth-First Search                                 |
+| Depth-First Search                                   |
+| Factorial                                            |
+| Forward List                                         |
+| Greatest Common Divisor                              |
+| Integer division ceiling                             |
+| List Bidirectional Iterator                          |
+| Primality Test                                       |
+| Tower of Hanoi                                       |
+| Wait-free (lock-free) SPSC append-only bounded queue |
 
 ### LeetCode problems
 

--- a/include/forfun/concurrency/spsc_bound_queue.hpp
+++ b/include/forfun/concurrency/spsc_bound_queue.hpp
@@ -1,0 +1,266 @@
+// Copyright (c) Omar Boukli-Hacene. All rights reserved.
+// Distributed under an MIT-style license that can be
+// found in the LICENSE file.
+
+// SPDX-License-Identifier: MIT
+
+#ifndef FORFUN_CONCURRENCY_SPSC_APPEND_QUEUE_HPP_
+#define FORFUN_CONCURRENCY_SPSC_APPEND_QUEUE_HPP_
+
+#include <array>
+#include <atomic>
+#include <bit>
+#include <cassert>
+#include <concepts>
+#include <cstddef>
+#include <execution>
+#include <iterator>
+#include <memory>
+#include <new>
+#include <span>
+#include <utility>
+
+namespace forfun::concurrency::wait_free {
+
+namespace detail {
+
+/// @note Assumes @p buffer is correctly aligned.
+template <typename Pointer, typename Offset>
+[[nodiscard]] constexpr auto
+get_ptr_to_obj(std::byte* const buffer, Offset const offset) noexcept -> Pointer
+{
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-align"
+#endif // defined(__GNUC__) && !defined(__clang__)
+
+    assert(
+        reinterpret_cast<std::uintptr_t>(
+            reinterpret_cast<Pointer>(buffer) + offset
+        ) % alignof(std::remove_pointer_t<Pointer>)
+        == 0UZ
+    );
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return reinterpret_cast<Pointer>(buffer) + offset;
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif // defined(__GNUC__) && !defined(__clang__)
+}
+
+/// @note Assumes @p buffer is correctly aligned.
+template <typename Pointer>
+[[nodiscard]] constexpr auto get_ptr_to_obj(std::byte* const buffer) noexcept
+    -> Pointer
+{
+    return get_ptr_to_obj<Pointer>(buffer, std::ptrdiff_t{});
+}
+
+using std::destroy_n;
+
+template <typename Pointer, typename Size>
+auto constexpr destroy_n(std::byte* const buffer, Size n) noexcept(noexcept(
+#if defined(__cpp_lib_execution) && __cpp_lib_execution >= 201603L
+    destroy_n(
+        std::execution::unseq, std::declval<Pointer>(), std::declval<Size>()
+    )
+#else
+    destroy_n(std::declval<Pointer>(), std::declval<Size>())
+#endif // defined(__cpp_lib_execution) && __cpp_lib_execution >= 201603L
+)) -> std::byte*
+{
+    using std::data;
+
+    auto* const ptr{get_ptr_to_obj<Pointer>(buffer)};
+
+#if defined(__cpp_lib_execution) && __cpp_lib_execution >= 201603L
+    return destroy_n(std::execution::unseq, ptr, n);
+#else
+    return destroy_n(ptr, n);
+#endif // defined(__cpp_lib_execution) && __cpp_lib_execution >= 201603L
+}
+
+} // namespace detail
+
+/// Single-producer single-consumer (SPSC) bound queue.
+///
+/// Features:
+/// - Wait-free (lock-free) concurrency model
+/// - First in, first out (FIFO) order semantics
+/// - Multi-pass reads via \c std::span
+/// - Bounded, fixed-capacity, and non-circular
+/// - Inline storage with no dynamic allocation
+/// - Append-only; elements are deconstructed when the queue is deconstructed.
+///
+/// @note The implementation prioritizes performance over safety and security.
+///
+/// @note Internal storage and padding area might not be (zero-)initialized.
+template <typename T, std::size_t Capacity>
+    requires std::destructible<T>
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init)
+class spsc_bound_queue final {
+private:
+    using pointer = T*;
+
+    using raw_queue_type = std::array<std::byte, Capacity * sizeof(T)>;
+
+public:
+    using size_type = std::size_t;
+
+    using value_type = T;
+
+    using reference = value_type&;
+
+    using span_type = std::span<value_type>;
+
+#ifdef _MSC_VER
+#pragma warning(push)
+// Warning C26495: Variable 'variable' is uninitialized. Always initialize a
+// member variable (type.6).
+#pragma warning(disable : 26495)
+#endif // _MSC_VER
+
+    spsc_bound_queue() = default;
+
+#ifdef _MSC_VER
+#pragma warning(pop) // C26495
+#endif // _MSC_VER
+
+    spsc_bound_queue(spsc_bound_queue const&) = delete;
+
+    spsc_bound_queue(spsc_bound_queue&&) = delete;
+
+    constexpr ~spsc_bound_queue() noexcept(noexcept(detail::destroy_n(
+        std::declval<typename raw_queue_type::pointer>(), capacity_
+    )))
+    {
+        using std::data;
+
+        if (write_cursor_cached_ == cursor_type{0})
+        {
+            return;
+        }
+
+        assert(write_cursor_cached_ <= static_cast<cursor_type>(capacity_));
+
+        detail::destroy_n(data(raw_queue_), write_cursor_cached_);
+    }
+
+    auto operator=(spsc_bound_queue const&) -> spsc_bound_queue& = delete;
+
+    auto operator=(spsc_bound_queue&&) -> spsc_bound_queue& = delete;
+
+    /// @note Padding area might not be (zero-)initialized. Instance-to-instance
+    /// comparision is undefined behavior.
+    auto operator<=>(spsc_bound_queue const&) const = delete;
+
+    /// @note Not thread-safe.
+    [[nodiscard]] auto empty_unsafe() const noexcept -> bool
+    {
+        using std::atomic_load_explicit;
+
+        return atomic_load_explicit(&write_cursor_, std::memory_order_relaxed)
+            == cursor_type{0};
+    }
+
+    /// @note Undefined behavior when pushing to a full container.
+    template <typename... Args>
+    auto emplace_back(Args&&... args) noexcept -> reference
+    {
+        using std::atomic_fetch_add_explicit;
+        using std::atomic_load_explicit;
+        using std::data;
+
+        static_assert(capacity_ != 0UZ);
+
+        assert(write_cursor_cached_ < static_cast<cursor_type>(capacity_));
+
+        auto* const ptr_emplaced{std::construct_at(
+            detail::get_ptr_to_obj<pointer>(
+                data(raw_queue_), write_cursor_cached_
+            ),
+            std::forward<Args>(args)...
+        )};
+
+        ++write_cursor_cached_;
+        atomic_store_explicit(
+            &write_cursor_, write_cursor_cached_, std::memory_order_release
+        );
+
+        return *ptr_emplaced;
+    }
+
+    [[nodiscard]] auto to_span() noexcept -> span_type
+    {
+        using std::atomic_load_explicit;
+        using std::data;
+
+        auto const cursor_snapshot{
+            atomic_load_explicit(&write_cursor_, std::memory_order_acquire)
+        };
+
+        return span_type(
+            detail::get_ptr_to_obj<pointer>(data(raw_queue_)),
+            static_cast<size_type>(cursor_snapshot)
+        );
+    }
+
+    [[nodiscard]] static consteval auto capacity() noexcept -> size_type
+    {
+        return capacity_;
+    }
+
+private:
+    static_assert(std::has_single_bit(Capacity));
+    static constexpr std::size_t const capacity_{Capacity};
+
+    /// Raw cursor type, without atomic wrapper.
+    using cursor_type = std::ptrdiff_t;
+
+    static_assert(std::atomic<cursor_type>::is_always_lock_free);
+
+    alignas(T) raw_queue_type raw_queue_
+        /*[[indeterminate]]*/;
+
+    static_assert(std::same_as<typename raw_queue_type::size_type, size_type>);
+    static_assert(std::same_as<typename span_type::size_type, size_type>);
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winterference-size"
+#endif // defined(__GNUC__) && !defined(__clang__)
+
+#ifdef _MSC_VER
+#pragma warning(push)
+// Warning C4324: 'type': structure was padded due to alignment specifier.
+#pragma warning(disable : 4324)
+#endif // _MSC_VER
+
+    alignas(
+        std::hardware_destructive_interference_size
+    ) std::atomic<cursor_type> write_cursor_{0};
+
+#ifdef _MSC_VER
+#pragma warning(pop) // C4324
+#endif // _MSC_VER
+
+    cursor_type write_cursor_cached_{0};
+
+    static_assert(
+        std::hardware_destructive_interference_size >= sizeof(cursor_type)
+    );
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif // defined(__GNUC__) && !defined(__clang__)
+
+    std::array<
+        std::byte,
+        std::hardware_destructive_interference_size - sizeof(cursor_type)>
+        end_of_object_padding_ /*[[indeterminate]]*/;
+};
+
+} // namespace forfun::concurrency::wait_free
+
+#endif // FORFUN_CONCURRENCY_SPSC_APPEND_QUEUE_HPP_

--- a/src/forfun/concurrency/spsc_bound_queue.cpp
+++ b/src/forfun/concurrency/spsc_bound_queue.cpp
@@ -1,0 +1,7 @@
+// Copyright (c) Omar Boukli-Hacene. All rights reserved.
+// Distributed under an MIT-style license that can be
+// found in the LICENSE file.
+
+// SPDX-License-Identifier: MIT
+
+#include "forfun/concurrency/spsc_bound_queue.hpp" // IWYU pragma: keep

--- a/test/concurrency/spsc_bound_queue_statictest.cpp
+++ b/test/concurrency/spsc_bound_queue_statictest.cpp
@@ -1,0 +1,88 @@
+// Copyright (c) Omar Boukli-Hacene. All rights reserved.
+// Distributed under an MIT-style license that can be
+// found in the LICENSE file.
+
+// SPDX-License-Identifier: MIT
+
+#include <concepts>
+#include <type_traits>
+#include <utility>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "forfun/concurrency/spsc_bound_queue.hpp"
+
+namespace {
+
+[[nodiscard]] consteval auto is_constexpr_destructor() noexcept -> bool
+{
+    {
+        forfun::concurrency::wait_free::spsc_bound_queue<int, 8> const queue{};
+    }
+
+    return true;
+}
+
+} // namespace
+
+TEST_CASE("Wait-free SPSC append-only bounded queue", "[spsc_bound_queue]")
+{
+    SECTION("Object representations is not unique")
+    {
+        STATIC_REQUIRE_FALSE(
+            std::has_unique_object_representations_v<
+                forfun::concurrency::wait_free::spsc_bound_queue<char, 8>>
+        );
+
+        STATIC_REQUIRE_FALSE(
+            std::has_unique_object_representations_v<
+                forfun::concurrency::wait_free::spsc_bound_queue<int, 8>>
+        );
+    }
+
+    SECTION("Construction and initialization")
+    {
+        STATIC_REQUIRE_FALSE(
+            std::copyable<
+                forfun::concurrency::wait_free::spsc_bound_queue<int, 8>>
+        );
+
+        STATIC_REQUIRE_FALSE(
+            std::movable<
+                forfun::concurrency::wait_free::spsc_bound_queue<int, 8>>
+        );
+    }
+
+    SECTION("Destructor call on empty queue")
+    {
+        STATIC_REQUIRE(is_constexpr_destructor());
+    }
+
+    SECTION("Comparision")
+    {
+        STATIC_REQUIRE_FALSE(
+            std::equality_comparable<
+                forfun::concurrency::wait_free::spsc_bound_queue<int, 8>>
+        );
+    }
+
+    SECTION("Capacity")
+    {
+        STATIC_REQUIRE(
+            forfun::concurrency::wait_free::spsc_bound_queue<int, 8>::capacity()
+            == 8UZ
+        );
+    }
+
+    SECTION("To span")
+    {
+        using queue_type
+            = forfun::concurrency::wait_free::spsc_bound_queue<int, 8>;
+
+        STATIC_REQUIRE(
+            std::same_as<
+                queue_type::span_type,
+                decltype(std::declval<queue_type>().to_span())>
+        );
+    }
+}

--- a/test/concurrency/spsc_bound_queue_test.cpp
+++ b/test/concurrency/spsc_bound_queue_test.cpp
@@ -1,0 +1,575 @@
+// Copyright (c) Omar Boukli-Hacene. All rights reserved.
+// Distributed under an MIT-style license that can be
+// found in the LICENSE file.
+
+// SPDX-License-Identifier: MIT
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <compare>
+#include <cstddef>
+#include <functional>
+#include <ranges>
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
+
+#include "forfun/concurrency/spsc_bound_queue.hpp"
+
+namespace {
+
+struct dummy_aggregate {
+    // NOLINTBEGIN(misc-non-private-member-variables-in-classes)
+    int a;
+
+    int b;
+
+    int c;
+
+    int d;
+    // NOLINTEND(misc-non-private-member-variables-in-classes)
+
+    auto operator<=>(dummy_aggregate const&) const -> std::strong_ordering
+        = default;
+};
+
+} // namespace
+
+TEST_CASE("Wait-free SPSC append-only bounded queue", "[spsc_bound_queue]")
+{
+    SECTION("Initial span is empty")
+    {
+        forfun::concurrency::wait_free::spsc_bound_queue<int, 8> queue{};
+
+        REQUIRE(queue.to_span().empty());
+    }
+
+    SECTION("Initially empty")
+    {
+        forfun::concurrency::wait_free::spsc_bound_queue<int, 8> const queue{};
+
+        REQUIRE(queue.empty_unsafe());
+    }
+
+    SECTION("Capacity")
+    {
+        forfun::concurrency::wait_free::spsc_bound_queue<int, 16> const queue{};
+
+        REQUIRE(queue.capacity() == 16UZ);
+    }
+
+    SECTION("Queue of std::byte")
+    {
+        forfun::concurrency::wait_free::spsc_bound_queue<std::byte, 16> const
+            queue{};
+
+        REQUIRE(queue.capacity() == 16UZ);
+    }
+
+    SECTION("Emplace affects empty state")
+    {
+        forfun::concurrency::wait_free::spsc_bound_queue<int, 2> queue{};
+
+        queue.emplace_back(677);
+
+        REQUIRE_FALSE(queue.empty_unsafe());
+
+        queue.emplace_back(683);
+
+        REQUIRE_FALSE(queue.empty_unsafe());
+    }
+
+    SECTION("Emplace affects span size")
+    {
+        forfun::concurrency::wait_free::spsc_bound_queue<int, 4> queue{};
+
+        queue.emplace_back(691);
+
+        REQUIRE(queue.to_span().size() == 1UZ);
+
+        queue.emplace_back(701);
+
+        REQUIRE(queue.to_span().size() == 2UZ);
+
+        queue.emplace_back(709);
+
+        REQUIRE(queue.to_span().size() == 3UZ);
+
+        queue.emplace_back(719);
+
+        REQUIRE(queue.to_span().size() == 4UZ);
+    }
+
+    SECTION("Emplace affects span back")
+    {
+        forfun::concurrency::wait_free::spsc_bound_queue<int, 4> queue{};
+
+        queue.emplace_back(-2);
+
+        REQUIRE(queue.to_span().front() == -2);
+
+        REQUIRE(queue.to_span().back() == -2);
+
+        queue.emplace_back(0);
+
+        REQUIRE(queue.to_span().back() == 0);
+
+        queue.emplace_back(-3);
+
+        REQUIRE(queue.to_span().back() == -3);
+
+        queue.emplace_back(12);
+
+        REQUIRE(queue.to_span().back() == 12);
+
+        REQUIRE(queue.to_span().front() == -2);
+    }
+
+    SECTION("Emplace returns reference to emplaced element")
+    {
+        forfun::concurrency::wait_free::spsc_bound_queue<int, 4> queue{};
+
+        decltype(auto) ref_to_emplaced{queue.emplace_back(225149)};
+
+        static_assert(std::is_reference_v<decltype(ref_to_emplaced)>);
+
+        REQUIRE(ref_to_emplaced == 225149);
+
+        REQUIRE(queue.to_span().front() == 225149);
+
+        ref_to_emplaced = 75773;
+
+        REQUIRE(queue.to_span().front() == 75773);
+    }
+
+    SECTION("Emplace till full then read all")
+    {
+        using ValueType = int;
+
+        static constexpr std::size_t const queue_capacity{8};
+
+        forfun::concurrency::wait_free::
+            spsc_bound_queue<ValueType, queue_capacity>
+                queue{};
+
+        for (
+            ValueType const n :
+            std::views::iota(ValueType{1}) | std::views::take(queue_capacity)
+        )
+        {
+            auto const& ref{queue.emplace_back(n)};
+            REQUIRE(ref == n);
+        }
+
+        REQUIRE_FALSE(queue.empty_unsafe());
+
+        REQUIRE(queue.to_span().size() == queue_capacity);
+
+        REQUIRE(
+            std::ranges::equal(
+                queue.to_span(),
+                std::views::iota(ValueType{1})
+                    | std::views::take(queue.to_span().size())
+            )
+        );
+    }
+
+    SECTION("To span")
+    {
+        forfun::concurrency::wait_free::spsc_bound_queue<int, 8> queue{};
+
+        queue.emplace_back(727);
+        queue.emplace_back(733);
+
+        auto const consumable_span{queue.to_span()};
+
+        REQUIRE(consumable_span.size() == 2UZ);
+
+        REQUIRE(consumable_span.front() == 727);
+
+        REQUIRE(consumable_span.back() == 733);
+    }
+
+    SECTION("Destructor call on empty queue")
+    {
+        {
+            forfun::concurrency::wait_free::spsc_bound_queue<int, 8> const
+                queue{};
+        }
+
+        SUCCEED();
+    }
+
+    SECTION("Destructor call on non-empty non-full queue")
+    {
+        {
+            forfun::concurrency::wait_free::spsc_bound_queue<int, 8> queue{};
+            queue.emplace_back(1);
+            queue.emplace_back(2);
+            queue.emplace_back(3);
+        }
+
+        SUCCEED();
+    }
+
+    SECTION("Destructor call on full queue")
+    {
+        {
+            forfun::concurrency::wait_free::spsc_bound_queue<int, 8> queue{};
+            queue.emplace_back(1);
+            queue.emplace_back(2);
+            queue.emplace_back(3);
+            queue.emplace_back(4);
+            queue.emplace_back(5);
+            queue.emplace_back(6);
+            queue.emplace_back(7);
+            queue.emplace_back(8);
+        }
+
+        SUCCEED();
+    }
+
+    SECTION("Nondeterministic one producer and one consumer of int values")
+    {
+        using std::equal_to;
+
+        static constexpr std::size_t const queue_size{8};
+
+        static constexpr auto const expected
+            = {208739, 208759, 208787, 208799, 208807, 208837, 208843, 208877};
+
+        using SizeType = forfun::concurrency::wait_free::
+            spsc_bound_queue<int, queue_size>::size_type;
+        using ValueType = forfun::concurrency::wait_free::
+            spsc_bound_queue<int, queue_size>::value_type;
+
+        forfun::concurrency::wait_free::spsc_bound_queue<int, queue_size>
+            queue{};
+
+        std::vector<ValueType> consumer_bag{};
+        consumer_bag.reserve(queue_size);
+
+        SizeType produced_count{};
+        SizeType consumed_count{};
+
+        {
+            std::jthread const
+            consumer([&queue, &consumer_bag, &consumed_count] -> void {
+                while (consumed_count < queue_size)
+                {
+                    for (auto&& val : queue.to_span().subspan(consumed_count))
+                    {
+                        consumer_bag.emplace_back(val);
+                        REQUIRE(std::ranges::contains(expected, val));
+                        ++consumed_count;
+                    }
+                }
+
+                REQUIRE(consumer_bag.size() == queue_size);
+            });
+
+            std::jthread const producer(
+                [&queue, &produced_count] noexcept -> void {
+                    for (auto&& val : expected)
+                    {
+                        queue.emplace_back(val);
+                        ++produced_count;
+                    }
+                }
+            );
+        }
+
+        REQUIRE(produced_count == queue_size);
+
+        REQUIRE(consumed_count == queue_size);
+
+        REQUIRE(produced_count == consumed_count);
+
+        REQUIRE(consumer_bag.size() == consumed_count);
+
+        REQUIRE(queue.to_span().size() == queue_size);
+
+        REQUIRE_THAT(consumer_bag, Catch::Matchers::RangeEquals(expected));
+    }
+
+    SECTION(
+        "Nondeterministic one producer and one consumer of aggregate values"
+    )
+    {
+        using std::equal_to;
+
+        static constexpr std::size_t const queue_size{8};
+
+        using ValueType = dummy_aggregate;
+
+        using SizeType = forfun::concurrency::wait_free::
+            spsc_bound_queue<ValueType, queue_size>::size_type;
+
+        forfun::concurrency::wait_free::spsc_bound_queue<ValueType, queue_size>
+            queue{};
+
+        std::vector<ValueType> consumer_bag{};
+        consumer_bag.reserve(queue_size);
+
+        SizeType produced_count{};
+        SizeType consumed_count{};
+
+        {
+            std::jthread const
+            consumer([&queue, &consumer_bag, &consumed_count] -> void {
+                while (consumed_count < queue_size)
+                {
+                    for (auto&& val : queue.to_span().subspan(consumed_count))
+                    {
+                        consumer_bag.emplace_back(val);
+                        ++consumed_count;
+                    }
+                }
+
+                REQUIRE(consumer_bag.size() == queue_size);
+            });
+
+            std::jthread const producer(
+                [&queue, &produced_count] noexcept -> void {
+                    for (
+                        auto&& n :
+                        std::views::iota(1) | std::views::take(queue_size)
+                    )
+                    {
+                        queue.emplace_back(n * 11, n * 2, n * 5, n * 10);
+                        ++produced_count;
+                    }
+                }
+            );
+        }
+
+        REQUIRE(produced_count == queue_size);
+
+        REQUIRE(consumed_count == queue_size);
+
+        REQUIRE(produced_count == consumed_count);
+
+        REQUIRE(consumer_bag.size() == consumed_count);
+
+        REQUIRE(queue.to_span().size() == queue_size);
+
+        int generator_state{1};
+        std::array<ValueType, queue_size> expected{};
+        for (auto& val : expected)
+        {
+            auto const n{generator_state++};
+            val = {.a = n * 11, .b = n * 2, .c = n * 5, .d = n * 10};
+        }
+
+        REQUIRE_THAT(consumer_bag, Catch::Matchers::RangeEquals(expected));
+    }
+
+    SECTION("Nondeterministic one producer and one consumer of int values")
+    {
+        using std::chrono::operator""ms;
+        using std::equal_to;
+
+        static constexpr std::size_t const queue_size{8};
+
+        static constexpr auto const expected
+            = {208739, 208759, 208787, 208799, 208807, 208837, 208843, 208877};
+
+        using SizeType = forfun::concurrency::wait_free::
+            spsc_bound_queue<int, queue_size>::size_type;
+        using ValueType = forfun::concurrency::wait_free::
+            spsc_bound_queue<int, queue_size>::value_type;
+
+        forfun::concurrency::wait_free::spsc_bound_queue<int, queue_size>
+            queue{};
+
+        std::vector<ValueType> consumer_bag{};
+        consumer_bag.reserve(queue_size);
+
+        SizeType produced_count{};
+        SizeType consumed_count{};
+
+        {
+            std::jthread const
+            consumer([&queue, &consumer_bag, &consumed_count] -> void {
+                while (consumed_count < queue_size)
+                {
+                    for (auto&& val : queue.to_span().subspan(consumed_count))
+                    {
+                        consumer_bag.emplace_back(val);
+                        REQUIRE(std::ranges::contains(expected, val));
+                        ++consumed_count;
+                    }
+                }
+
+                REQUIRE(consumer_bag.size() == queue_size);
+            });
+
+            std::jthread const producer(
+                [&queue, &produced_count] noexcept -> void {
+                    std::this_thread::sleep_for(10ms);
+
+                    for (auto&& val : expected)
+                    {
+                        std::this_thread::sleep_for(3ms);
+
+                        queue.emplace_back(val);
+                        ++produced_count;
+                    }
+                }
+            );
+        }
+
+        REQUIRE(produced_count == queue_size);
+
+        REQUIRE(consumed_count == queue_size);
+
+        REQUIRE(produced_count == consumed_count);
+
+        REQUIRE(consumer_bag.size() == consumed_count);
+
+        REQUIRE(queue.to_span().size() == queue_size);
+
+        REQUIRE_THAT(consumer_bag, Catch::Matchers::RangeEquals(expected));
+    }
+
+    SECTION(
+        "Nondeterministic one producer and one consumer of aggregate values"
+    )
+    {
+        using std::chrono::operator""ms;
+        using std::equal_to;
+
+        static constexpr std::size_t const queue_size{8};
+
+        using ValueType = dummy_aggregate;
+
+        using SizeType = forfun::concurrency::wait_free::
+            spsc_bound_queue<ValueType, queue_size>::size_type;
+
+        forfun::concurrency::wait_free::spsc_bound_queue<ValueType, queue_size>
+            queue{};
+
+        std::vector<ValueType> consumer_bag{};
+        consumer_bag.reserve(queue_size);
+
+        SizeType produced_count{};
+        SizeType consumed_count{};
+
+        {
+            std::jthread const
+            consumer([&queue, &consumer_bag, &consumed_count] -> void {
+                while (consumed_count < queue_size)
+                {
+                    for (auto&& val : queue.to_span().subspan(consumed_count))
+                    {
+                        consumer_bag.emplace_back(val);
+                        ++consumed_count;
+                    }
+                }
+
+                REQUIRE(consumer_bag.size() == queue_size);
+            });
+
+            std::jthread const producer(
+                [&queue, &produced_count] noexcept -> void {
+                    std::this_thread::sleep_for(10ms);
+
+                    for (
+                        auto&& n :
+                        std::views::iota(1) | std::views::take(queue_size)
+                    )
+                    {
+                        std::this_thread::sleep_for(10ms);
+
+                        queue.emplace_back(n * 111, n * 4, n * 8, n * 20);
+                        ++produced_count;
+                    }
+                }
+            );
+        }
+
+        REQUIRE(produced_count == queue_size);
+
+        REQUIRE(consumed_count == queue_size);
+
+        REQUIRE(produced_count == consumed_count);
+
+        REQUIRE(consumer_bag.size() == consumed_count);
+
+        REQUIRE(queue.to_span().size() == queue_size);
+
+        int generator_state{1};
+        std::array<ValueType, queue_size> expected{};
+        for (auto& val : expected)
+        {
+            auto const n{generator_state++};
+            val = {.a = n * 111, .b = n * 4, .c = n * 8, .d = n * 20};
+        }
+
+        REQUIRE_THAT(consumer_bag, Catch::Matchers::RangeEquals(expected));
+    }
+
+    SECTION("Benchmark case")
+    {
+        static constexpr std::size_t const capacity{16};
+
+        // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+        int volatile val /*[[indeterminate]]*/;
+        forfun::concurrency::wait_free::spsc_bound_queue<int, capacity> queue{};
+
+        queue.emplace_back(502807);
+        val = queue.to_span().back();
+
+        queue.emplace_back(502807);
+        val = queue.to_span().back();
+
+        queue.emplace_back(502807);
+        val = queue.to_span().back();
+
+        queue.emplace_back(502807);
+        val = queue.to_span().back();
+
+        queue.emplace_back(502807);
+        val = queue.to_span().back();
+
+        queue.emplace_back(502807);
+        val = queue.to_span().back();
+
+        queue.emplace_back(502807);
+        val = queue.to_span().back();
+
+        queue.emplace_back(502807);
+        val = queue.to_span().back();
+
+        queue.emplace_back(502807);
+        val = queue.to_span().back();
+
+        queue.emplace_back(502807);
+        val = queue.to_span().back();
+
+        queue.emplace_back(502807);
+        val = queue.to_span().back();
+
+        queue.emplace_back(502807);
+        val = queue.to_span().back();
+
+        queue.emplace_back(502807);
+        val = queue.to_span().back();
+
+        queue.emplace_back(502807);
+        val = queue.to_span().back();
+
+        queue.emplace_back(502807);
+        val = queue.to_span().back();
+
+        queue.emplace_back(502807);
+        val = queue.to_span().back();
+
+        REQUIRE(val == 502807);
+    }
+}


### PR DESCRIPTION
Add a basic wait-free single producer, single consumer bounded queue, written in C++23 and provided along with:

- Unit tests, and static unit test, within Catch2 hosts
- Basic benchmarking
- Elaborate CI with
  - Multi-compiler, multi-configuration builds
  - LLVM and Xcode ASan, UBSan, and TSan
  - Testing and code coverage instrumentation.

Source code (header-only) at `include/forfun/concurrency/spsc_bound_queue.hpp`